### PR TITLE
Fixed dependency in compiz-bcop PKGBUILD.

### DIFF
--- a/compiz/compiz-bcop/PKGBUILD
+++ b/compiz/compiz-bcop/PKGBUILD
@@ -11,7 +11,7 @@ pkgdesc="Compiz option code generator"
 arch=('any')
 url="http://www.compiz.org"
 license=('GPL')
-depends=('compiz-core>=${pkgver}' 'libxslt')
+depends=("compiz-core>=${pkgver}" 'libxslt')
 makedepends=('intltool')
 conflicts=('compiz-bcop-dev')
 source=("http://www.northfield.ws/projects/compiz/releases/${pkgver}/${_pkgname}.tar.gz")


### PR DESCRIPTION
Single quotes prevent shell expansion of ${pkgver}.  Replaced with double quotes.
